### PR TITLE
List fontware package as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ installation, are necessary:
 * MnSymbol for MinionPro, MdSymbol for MyriadPro
 * fltpoint package
 * tabfigures package (optional)
+* fontware package (usually, but not always, comes with your Tex
+  distribution)
 
 
 Supported font styles


### PR DESCRIPTION
Some required tools, e.g. `vptovf` and `pltotf`, are contained in the fontware package. This package is usually installed with the tex distribution (e.g. texlive), but it is omitted in other minimalist ones (e.g. basictex).

It would be nice to list it as a requirement; installing it again would be a no-op for most users, while it would save users of smaller distributions like basictex the pain and confusion (esp because `./scripts/makeall` doesn't fail immediately without the package).
