### PR TITLE
Support FreeBSD, parallelize maketfm

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ type tools in Cygwin from source or install the
 
 3. Run the main script `makeall`:
 
-        $ ./scripts/makeall $FONT
+        $ ./scripts/makeall $FONT [options]
 
    Currently, `$FONT` can be MinionPro, MyriadPro or CronosPro.
 

--- a/scripts/beautify-enc.sh
+++ b/scripts/beautify-enc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ed -s "$1" <<EOF
 /\[/a

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Remove generated files from the source tree
 
 # quick sanity check: Are we in the top-level directory?

--- a/scripts/fix-map
+++ b/scripts/fix-map
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Fix map lines referring to .otf fonts (resulting from otftotfm not finding
 # the .pfb because they have not yet been installed: Happens either before the
 # first installation if otftotfm is compiled with kpathsea support or in any

--- a/scripts/generate-glyph-list.sh
+++ b/scripts/generate-glyph-list.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cat dvips/a_*.enc |
 sed -e 's/^.*\[//' -e 's/^%.*$//' |

--- a/scripts/install
+++ b/scripts/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 vendor=adobe
 font=`cat fontname`

--- a/scripts/makeall
+++ b/scripts/makeall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ffamily=$1
 shift

--- a/scripts/makeint-CronosPro.cfg
+++ b/scripts/makeint-CronosPro.cfg
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 prefix=Cr

--- a/scripts/makeint-MyriadPro.cfg
+++ b/scripts/makeint-MyriadPro.cfg
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 prefix=My

--- a/scripts/maketfm
+++ b/scripts/maketfm
@@ -273,10 +273,11 @@ make_base_fonts() {
 
         echo "$font-$name-Base-$i$exp_suffix $enc" >>"$font_list"
 
-        otftotfm $common_flags $exp_flags --literal-encoding="$enc" "otf/$font-$name.otf" "$font-$name-Base-$i$exp_suffix"
+        otftotfm $common_flags $exp_flags --literal-encoding="$enc" "otf/$font-$name.otf" "$font-$name-Base-$i$exp_suffix" &
       done
 
     done
+    wait
   fi
 }
 
@@ -335,8 +336,9 @@ make_tfm() {
       progress -n " $spec$exp_suffix,"
     fi
 
-    echo "otftotfm $common_flags $base_encoding_flags $exp_flags $* $enc_flags 'otf/$font-$name.otf' '$tex_name'" >>maketfm.tmp
+    echo "otftotfm $common_flags $base_encoding_flags $exp_flags $* $enc_flags 'otf/$font-$name.otf' '$tex_name' &" >>maketfm.tmp
   done
+  echo "wait" >>maketfm.tmp
 }
 
 make_ligkern_options() {

--- a/scripts/maketfm
+++ b/scripts/maketfm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check utilities.
 
@@ -727,7 +727,7 @@ make_base_encodings
 
 # We first create a shell script with the actual otftotfm calls.
 
-echo "#!/bin/bash" >maketfm.tmp
+echo "#!/usr/bin/env bash" >maketfm.tmp
 
 for weight in Light "" Medium Semibold Bold Black
 do

--- a/scripts/maketfm-CronosPro.cfg
+++ b/scripts/maketfm-CronosPro.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 create_vietnamese=false
 create_greek=false

--- a/scripts/maketfm-GaramondPremrPro.cfg
+++ b/scripts/maketfm-GaramondPremrPro.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 oml_flags="$oml_flags --include-alternates 'rho.alt' -fsalt"
 oml_flags="$oml_flags --unicoding 'rho1 =: rho'"

--- a/scripts/maketfm-MinionPro.cfg
+++ b/scripts/maketfm-MinionPro.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Determine version of the fonts.
 

--- a/scripts/maketfm-MyriadPro.cfg
+++ b/scripts/maketfm-MyriadPro.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Determine version of the fonts.
 case $(otfinfo -v otf/$font-Regular.otf) in


### PR DESCRIPTION
Hi. I tried to install Myriad Pro and Minion Pro on FreeBSD with your scripts.
To make it work, I had to replace the hard-coded paths to `bash`. Then, it worked fine.

If you don't mind, I also added a mention to `README.md` explaining that arguments come after the font name for `makeall` and added a bit of parallelization to `maketfm` so that it finishes in acceptable time even with `--expanded`.

What do you think of those changes? Feel free to edit them.